### PR TITLE
Support Py version where async is keyword: fix #11

### DIFF
--- a/api/api_client_temp.py
+++ b/api/api_client_temp.py
@@ -283,7 +283,7 @@ class ApiClientTemp(object):
     def call_api(self, resource_path, method,
                  path_params=None, query_params=None, header_params=None,
                  body=None, post_params=None, files=None,
-                 response_type=None, auth_settings=None, async=None,
+                 response_type=None, auth_settings=None, async_=None,
                  _return_http_data_only=None, collection_formats=None, _preload_content=True,
                  _request_timeout=None):
         """
@@ -303,7 +303,7 @@ class ApiClientTemp(object):
         :param response: Response data type.
         :param files dict: key -> filename, value -> filepath,
             for `multipart/form-data`.
-        :param async bool: execute request asynchronously
+        :param async_ bool: execute request asynchronously
         :param _return_http_data_only: response data without head status code and headers
         :param collection_formats: dict of collection formats for path, query,
             header, and post parameters.
@@ -312,13 +312,13 @@ class ApiClientTemp(object):
         :param _request_timeout: timeout setting for this request. If one number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of (connection, read) timeouts.
         :return:
-            If async parameter is True,
+            If async_ parameter is True,
             the request will be called asynchronously.
             The method will return the request thread.
-            If parameter async is False or missing,
+            If parameter async_ is False or missing,
             then the method will return the response directly.
         """
-        if not async:
+        if not async_:
             return self.__call_api(resource_path, method,
                                    path_params, query_params, header_params,
                                    body, post_params, files,


### PR DESCRIPTION
This commit changes `async=None` -> `async_=None` to support Python versions where `async` is a keyword.

Fixes #11