### PR TITLE
Use yaml.safe_load instead of yaml.load

### DIFF
--- a/static_risky_roles.py
+++ b/static_risky_roles.py
@@ -22,7 +22,7 @@ def set_risky_roles_from_yaml(items):
 
 with open(os.path.dirname(os.path.realpath(__file__)) + '/risky_roles.yaml', 'r') as stream:
     try:
-        loaded_yaml = yaml.load(stream)
+        loaded_yaml = yaml.safe_load(stream)
         set_risky_roles_from_yaml(loaded_yaml['items'])
     except yaml.YAMLError as exc:
         print(exc)


### PR DESCRIPTION
TLDR: `yaml.load` can deserialize Python objects and so is insecure. Though, this is rather a cosmetic change here as `risky_roles.yaml` is static anyway.