### PR TITLE
Simplify dockerfile + Parameterize paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,66 @@
-FROM ubuntu:latest
-RUN apt-get update
-RUN apt-get install -y python3 python3-pip
-RUN pip3 install kubernetes
-RUN pip3 install PTable
-RUN echo "alias kubiscan='python3 /KubiScan/KubiScan.py'" > /root/.bash_aliases
-RUN . /root/.bash_aliases
-RUN apt-get remove -y python3-pip
-COPY . /KubiScan
+# Default to the Docker Hub container registry
+ARG DOCKER_REGISTRY=index.docker.io
+
+# Default to the official Python Debian image
+ARG PYTHON_IMAGE=${DOCKER_REGISTRY}/python:3.8.0-slim-buster
+
+
+FROM ${PYTHON_IMAGE} AS build-image
+
+WORKDIR /tmp/build-kubiscan
+COPY requirements.txt requirements.txt
+
+# The default image provides `pip`, `pip3`, `python` and `python3` commands and
+# for portability's sake, the `pip3` and `python3` names will be used in this
+# configuration.
+
+# Install Python dependencies from requirements.txt
+# As customary with Python projects, the requirements.txt, when provided,
+# should contain all packages necessary to run the Python source for the
+# project. As such changes to the dependencies would merely warrant a change to
+# the requirements.txt file, while the Dockerfile files remain unaffected.
+RUN pip3 install -r requirements.txt
+
+
+FROM ${PYTHON_IMAGE} AS run-image
+# Copy Python packages installed in the build stage
+COPY --from=build-image /usr/local /usr/local
+
+# Copy source
+COPY . /opt/kubiscan
+
+# Create kubiscan executable shortcut for all users
+# NOTE that this image does not default to using this shortcut but rather
+# resorts to directly starting the KubiScan Python script. It may prove useful
+# to remove this shortcut altogether unless end-users are expected to spawn a
+# Bash inside the resulting container in which case the `kubiscan` shortcut
+# will come in handy.
+RUN set -ex \
+  && echo 'python3 /opt/kubiscan/KubiScan.py $@' > /usr/local/bin/kubiscan \
+  && chmod a+x /usr/local/bin/kubiscan \
+  && which kubiscan
+
+# Create a non-root user and group
+RUN set -ex \
+  && addgroup kubiscan \
+  && adduser \
+    --no-create-home \
+    --disabled-password \
+    --gecos ',,,,' \
+    --ingroup kubiscan \
+    --disabled-login \
+    kubiscan \
+  && > /var/log/faillog \
+  && > /var/log/lastlog
+
+# Default to the previously created kubiscan user
+USER kubiscan
+
+# Test runnability of the shortcut by invoking the command to list examples
+RUN kubiscan --examples
+
+# Default to /tmp/kubiscan/kubeconfig
+ENV CONF_PATH=/kubiscan/kubeconfig
+
+ENTRYPOINT ["python3", "/opt/kubiscan/KubiScan.py"]
+CMD ["--examples"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ USER kubiscan
 RUN kubiscan --examples
 
 # Default to /tmp/kubiscan/kubeconfig
-ENV CONF_PATH=/kubiscan/kubeconfig
+ENV CONF_PATH=/kubiscan/kubeconfig.yaml
 
 ENTRYPOINT ["python3", "/opt/kubiscan/KubiScan.py"]
 CMD ["--examples"]

--- a/KubiScan.py
+++ b/KubiScan.py
@@ -387,7 +387,7 @@ def print_join_token():
         ca_cert = '/etc/kubernetes/ca.crt'
 
     if running_in_docker_container():
-        ca_cert = '/tmp' + ca_cert
+        ca_cert = os.getenv('KUBISCAN_VOLUME_PATH', '/tmp') + ca_cert
 
     join_token_path = os.path.dirname(os.path.realpath(__file__)) + '/engine/join_token.sh'
     tokens = engine.utils.list_boostrap_tokens_decoded()

--- a/README.md
+++ b/README.md
@@ -24,13 +24,56 @@ KubiScan gathers information about risky roles\clusterroles, rolebindings\cluste
 
 ## Usage
 ### Container
-#### With `~/.kube/config` file
-This should be executed within the **Master** node where the config file is located:  
-`docker run -it --rm -e CONF_PATH=~/.kube/config -v /:/tmp cyberark/kubiscan`  
-* `CONF_PATH` - the cluster config file's path  
+Build the Docker image using
 
-Inside the container the command `kubiscan` is equivalent to `python3 /KubiScan/KubiScan.py`.  
-Notice that in this case, the **whole file system will be mounted**. This is due to the fact that the config files contain paths to other places in the filesystem that will be different in other environments.  
+```
+docker build -t kubiscan .
+```
+
+> For usage within Docker, it should be noted that KubiScan expects to be able
+> to write to `/KubiScan`. The examples below mount a directory indicated by
+> the KUBISCAN_VOLUME variable as a writable volume to the container's
+> `/KubiScan` path into which KubiScan will write a config_bak file.
+
+The following variables are recognized by the application:
+- `KUBISCAN_CONFIG_PATH` path to the mounted kubeconfig, undefined by default
+  and setting this skips the previous behaviour (see
+  [source][running-in-docker]) and renders to `KUBISCAN_CONFIG_BACKUP_PATH` and
+  `KUBISCAN_VOLUME_PATH` obsolete as the branches utilizing these become
+  unreachable.
+- `KUBISCAN_CONFIG_BACKUP_PATH` path to the config_bak path, defaults to
+  `/KubiScan/config_bak`
+- `KUBISCAN_VOLUME_PATH` defaults to `/tmp`
+
+[running-in-docker]: https://github.com/cyberark/KubiScan/blob/2531bbdd268c9a7c729a2e6826590516c6aab201/api/api_client.py#L59
+
+#### With `~/.kube/config` file
+This should be executed within the **Master** node where the config file is located:
+
+```
+docker run -it --rm \
+  -v ~/.kube/config:/tmp/kubiscan/kubeconfig.yaml:ro \
+  -e KUBISCAN_CONFIG_PATH=/tmp/kubiscan/kubeconfig.yaml \
+  kubiscan <command>
+```
+
+Replace `<command>` with the actual arguments to the KubiScan application that you want to run.
+
+```
+# Example running `kubiscan --help`
+docker run -it --rm \
+  -v ~/.kube/config:/tmp/kubiscan/kubeconfig.yaml:ro \
+  -e KUBISCAN_CONFIG_PATH=/tmp/kubiscan/kubeconfig.yaml \
+  kubiscan --help
+```
+
+```
+# Example running `kubiscan --all`
+docker run -it --rm \
+  -v ~/.kube/config:/tmp/kubiscan/kubeconfig.yaml:ro \
+  -e KUBISCAN_CONFIG_PATH=/tmp/kubiscan/kubeconfig.yaml \
+  kubiscan --all
+```
 
 #### With service account token (good from remote)
 It requires a **privileged** service account with the following permissions:  
@@ -79,8 +122,23 @@ EOF
 Save the service account's token to a file:  
 `kubectl get secrets $(kubectl get sa kubiscan-sa -o=jsonpath='{.secrets[0].name}') -o=jsonpath='{.data.token}' | base64 -d > token`
 
-Run the container from anywhere you want:  
-`docker run -it --rm -v $PWD/token:/token cyberark/kubiscan`  
+> Note that a valid kubeconfig can be configured to utilize the token by
+> updating the `users` object to contain the appropriate `name` and
+> `user.token` values.  Arguably, the usage of kubeconfig files is a more
+> idiomatic and user-friendly approach to connecting to Kubernetes clusters.
+
+Spawn a Bash shell into the container:
+```
+docker run -it --rm \
+  -v ${TOKEN_PATH}/token:/tmp/kubiscan/token:ro \
+  -v ${KUBISCAN_VOLUME}:/KubiScan \
+  --entrypoint=bash kubiscan
+```
+
+> Note that the directory represented by the `KUBISCAN_VOLUME` variable should
+> be writable because KubiScan, when running inside a Docker container, expects
+> a `/KubiScan/config_bak` file (see [source][running-in-docker]) and will
+> attempt to create /KubiScan/config_bak when missing.
 
 In the shell you will be able to to use kubiscan like that:   
 `kubiscan -ho <master_ip:master_port> -t /token <command>`  

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ EOF
 ```
 
 Save the service account's token to a file:  
-`kubectl get secrets $(kubectl get sa kubiscan-sa -o json | jq -r '.secrets[0].name') -o json | jq -r '.data.token' | base64 -d > token` 
+`kubectl get secrets $(kubectl get sa kubiscan-sa -o=jsonpath='{.secrets[0].name}') -o=jsonpath='{.data.token}' | base64 -d > token`
 
 Run the container from anywhere you want:  
 `docker run -it --rm -v $PWD/token:/token cyberark/kubiscan`  

--- a/api/api_client.py
+++ b/api/api_client.py
@@ -59,11 +59,11 @@ def api_init(host=None, token_filename=None, cert_filename=None, context=None):
         if running_in_docker_container():
             # TODO: Consider using config.load_incluster_config() from container created by Kubernetes. Required service account with privileged permissions.
             # Must have mounted volume
-            container_volume_prefix = '/tmp'
-            kube_config_bak_path = '/KubiScan/config_bak'
+            container_volume_prefix = os.getenv('KUBISCAN_VOLUME_PATH', '/tmp')
+            kube_config_bak_path = os.getenv('KUBISCAN_CONFIG_BACKUP_PATH', '/KubiScan/config_bak')
             if not os.path.isfile(kube_config_bak_path):
                 copyfile(container_volume_prefix + os.path.expandvars('$CONF_PATH'), kube_config_bak_path)
-                replace(kube_config_bak_path, ': /', ': /tmp/')
+                replace(kube_config_bak_path, ': /', f': {container_volume_prefix}/')
 
             config.load_kube_config(kube_config_bak_path, context=context)
         else:

--- a/api/api_client.py
+++ b/api/api_client.py
@@ -56,7 +56,8 @@ def api_init(host=None, token_filename=None, cert_filename=None, context=None):
         BearerTokenLoader(host=host, token_filename=token_filename, cert_filename=cert_filename).load_and_set()
 
     else:
-        if running_in_docker_container():
+        kubeconfig_path = os.getenv('KUBISCAN_CONFIG_PATH')
+        if running_in_docker_container() and kubeconfig_path is None:
             # TODO: Consider using config.load_incluster_config() from container created by Kubernetes. Required service account with privileged permissions.
             # Must have mounted volume
             container_volume_prefix = os.getenv('KUBISCAN_VOLUME_PATH', '/tmp')
@@ -67,7 +68,7 @@ def api_init(host=None, token_filename=None, cert_filename=None, context=None):
 
             config.load_kube_config(kube_config_bak_path, context=context)
         else:
-            config.load_kube_config(context=context)
+            config.load_kube_config(config_file=kubeconfig_path, context=context)
 
     CoreV1Api = client.CoreV1Api()
     RbacAuthorizationV1Api = client.RbacAuthorizationV1Api()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-kubernetes
-PrettyTable
-urllib3
+kubernetes==11.0.0
+PTable==0.9.2


### PR DESCRIPTION
- Pin Python dependencies to versions (see requirements.txt)
- Improve security of container
  - reduce the scope of mounted artefacts into the image such that one can mount just the files that are actually relevant to KubiScan instead of dagerously mounting `/`
  - operate as a non-root user (kubiscan) inside the container
- Improve portability of KubiScan
  - parameterize paths in exchange for hardcoded values in a manner such that undefined parameters default to their previously hardcoded values
    - `KUBISCAN_VOLUME_PATH` defaults to `/tmp` for backwards compatability
    - `KUBISCAN_CONFIG_BACKUP_PATH` defaults to `/KubiScan/config_bak` for backwards compatability
  - introduce `KUBISCAN_CONFIG_PATH` in order to explicitly set the path to the kubeconfig file and therefore skip through the additional logic for runs inside a Docker container (which IMO adds unnecessary complexity since the application behaves differently depending on its environment while this can be eliminated by requiring the end-user to explicitly set the path to the kubeconfig file)
  - set `ENTRYPOINT` and `COMMAND` in order to simplify CLI and CI usage
- Reduce size of image by use of multi-stage build to isolate build artefacts from runtime requirements
- Improve FHS-compliance of the KubiScan docker image and thus make it easier to people familiar with the FHS standard to reason about the purpose of the files
  - install KubiScan to /opt/kubiscan which is a destination for add-on application packages