### PR TITLE
Remove warnings when TLS verificaition is turned off when using a token / no CA file

### DIFF
--- a/api/api_client.py
+++ b/api/api_client.py
@@ -82,6 +82,8 @@ class BearerTokenLoader(object):
 
         if not self._cert_filename:
             self._verify_ssl = False
+            import urllib3
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     def load_and_set(self):
         self._load_config()

--- a/engine/utils.py
+++ b/engine/utils.py
@@ -10,9 +10,6 @@ from api import api_client
 from engine.subject import Subject
 from misc.constants import *
 from kubernetes.client.rest import ApiException
-import urllib3
-# Using it to disable warning when using only bearer token without ca.crt to verify the SSL
-#urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 #region - Roles and ClusteRoles
 


### PR DESCRIPTION
This just moves the urllib3 warning suppression line to be enable automatically, when token auth is used. Should fix #5 . Tested with/without CA when using token. Have encountered no issues during my own testing.