### PR TITLE
Fix for pod.spec.volumes with None 

### DIFF
--- a/engine/privleged_containers.py
+++ b/engine/privleged_containers.py
@@ -49,16 +49,16 @@ def get_privileged_containers(namespace=None):
                             found_privileged_container = True
                             break
                 if not found_privileged_container:
-                    for volume in pod.spec.volumes:
-                        if found_privileged_container:
-                            break
-                        if volume.host_path:
-                            for volume_mount in container.volume_mounts:
-                                 if volume_mount.name == volume.name:
-                                     privileged_containers.append(container)
-                                     found_privileged_container = True
-                                     break
-
+                    if pod.spec.volumes is not None:
+                      for volume in pod.spec.volumes:
+                          if found_privileged_container:
+                              break
+                          if volume.host_path:
+                              for volume_mount in container.volume_mounts:
+                                   if volume_mount.name == volume.name:
+                                       privileged_containers.append(container)
+                                       found_privileged_container = True
+                                       break
         if privileged_containers:
             pod.spec.containers = privileged_containers
             privileged_pods.append(pod)

--- a/engine/utils.py
+++ b/engine/utils.py
@@ -330,9 +330,10 @@ def get_risky_containers(pod, risky_users, read_token_from_container=False):
         for container in pod.spec.containers:
             pod_mounted_secrets = {}
 	    # TODO: Use VolumeMount from the container for more reliable results
-            for volume in pod.spec.volumes:
-                if volume.secret:
-                    pod_mounted_secrets[volume.secret.secret_name] = True
+            if pod.spec.volumes is not None:
+              for volume in pod.spec.volumes:
+                  if volume.secret:
+                      pod_mounted_secrets[volume.secret.secret_name] = True
 
             jwt_body = get_jwt_token_from_container_by_etcd(pod, container, pod_mounted_secrets)
             if jwt_body:


### PR DESCRIPTION
In some scenarios, pod can have empty `volumes` field under it specs, in such case we are not checking if the `volumes` is `None` and therefore result with a panic like that:  
```
 Traceback (most recent call last):
   File "/KubiScan/KubiScan.py", line 635, in <module>
     main()
   File "/KubiScan/KubiScan.py", line 568, in main
     print_all_risky_containers(priority=args.priority, namespace=args.namespace, read_token_from_container=args.deep)
   File "/KubiScan/KubiScan.py", line 113, in print_all_risky_containers
     pods = engine.utils.get_risky_pods(namespace, read_token_from_container)
   File "/KubiScan/engine/utils.py", line 350, in get_risky_pods
     risky_containers = get_risky_containers(pod, risky_users, deep_analysis)
   File "/KubiScan/engine/utils.py", line 331, in get_risky_containers
     for volume in pod.spec.volumes:
 TypeError: 'NoneType' object is not iterable
```

**Reproduce:**
Create a pod with this YAML:  
 ```
apiVersion: v1
kind: Pod
metadata:
  name: super-user-pod
spec:
  containers:
  - image: busybox:1.28
    imagePullPolicy: IfNotPresent
    name: redis
    resources: {}
    securityContext:
      capabilities:
        add:
        - SYS_ADMIN
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  restartPolicy: Always
  automountServiceAccountToken: false
```

To fix it, I added support for empty `pod.spec.volumes` in two places:

This should solve case: Python error not handled when command result is empty #12