### PR TITLE
fix 'NoneType' object is not iterable when running on OpenShift

### DIFF
--- a/api/api_client_temp.py
+++ b/api/api_client_temp.py
@@ -318,21 +318,21 @@ class ApiClientTemp(object):
             If parameter async_req is False or missing,
             then the method will return the response directly.
         """
-        if not async_req:
-            return self.__call_api(resource_path, method,
-                                   path_params, query_params, header_params,
-                                   body, post_params, files,
-                                   response_type, auth_settings,
-                                   _return_http_data_only, collection_formats, _preload_content, _request_timeout)
-        else:
-            thread = self.pool.apply_async(self.__call_api, (resource_path, method,
-                                                             path_params, query_params,
-                                                             header_params, body,
-                                                             post_params, files,
-                                                             response_type, auth_settings,
-                                                             _return_http_data_only,
-                                                             collection_formats, _preload_content, _request_timeout))
-        return thread
+        # if not async_req:
+        return self.__call_api(resource_path, method,
+                                path_params, query_params, header_params,
+                                body, post_params, files,
+                                response_type, auth_settings,
+                                _return_http_data_only, collection_formats, _preload_content, _request_timeout)
+        #else:
+        #    thread = self.pool.apply_async(self.__call_api, (resource_path, method,
+        #                                                     path_params, query_params,
+        #                                                     header_params, body,
+        #                                                     post_params, files,
+        #                                                     response_type, auth_settings,
+        #                                                     _return_http_data_only,
+        #                                                     collection_formats, _preload_content, _request_timeout))
+        #return thread
 
     def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True, _request_timeout=None):

--- a/api/api_client_temp.py
+++ b/api/api_client_temp.py
@@ -658,7 +658,7 @@ class ApiClientTemp(object):
         return cluster_role_bindings
 
     def list_cluster_role(self):
-        json_data = self.__call_api('/apis/rbac.authorization.k8s.io/v1/clusterroles', 'GET',
+        json_data = self.__call_api(resource_path='/apis/rbac.authorization.k8s.io/v1/clusterroles', method='GET',
                                         path_params={}, query_params=[],
                                         header_params={'Content-Type': 'application/json', 'Accept': 'application/json'},
                                         body=None, post_params=[], files={},

--- a/api/api_client_temp.py
+++ b/api/api_client_temp.py
@@ -67,7 +67,7 @@ class ApiClientTemp(object):
             configuration = Configuration()
         self.configuration = configuration
 
-        self.pool = ThreadPool()
+        #self.pool = ThreadPool()
         self.rest_client = RESTClientObject(configuration)
         self.default_headers = {}
         if header_name is not None:
@@ -76,9 +76,6 @@ class ApiClientTemp(object):
         # Set default User-Agent.
         self.user_agent = 'Swagger-Codegen/6.0.0/python'
 
-    def __del__(self):
-        self.pool.close()
-        self.pool.join()
 
     @property
     def user_agent(self):

--- a/engine/utils.py
+++ b/engine/utils.py
@@ -78,12 +78,13 @@ def are_rules_contain_other_rules(source_role_name, source_rules, target_rules):
     is_contains = False
     matched_rules = 0
     for target_rule in target_rules:
-        for source_rule in source_rules:
-            if is_rule_contains_risky_rule(source_role_name, source_rule, target_rule):
-                matched_rules += 1
-                if matched_rules == len(target_rules):
-                    is_contains = True
-                    return is_contains
+        if source_rules is not None:
+            for source_rule in source_rules:
+                if is_rule_contains_risky_rule(source_role_name, source_rule, target_rule):
+                    matched_rules += 1
+                    if matched_rules == len(target_rules):
+                        is_contains = True
+                        return is_contains
 
     return is_contains
 


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made? 'NoneType' object is not iterable error when running -rr on OpenShift
- _How should the reviewer approach this PR, especially if manual tests are required? Determine if the additional check is ok
- _Are there relevant screenshots you can add to the PR description? Stack trace:

```
Traceback (most recent call last):
  File "./KubiScan/KubiScan.py", line 635, in <module>
    main()
  File "./KubiScan/KubiScan.py", line 554, in main
    print_risky_roles(show_rules=args.rules, days=args.less_than, priority=args.priority)
  File "./KubiScan/KubiScan.py", line 52, in print_risky_roles
    risky_roles = engine.utils.get_risky_roles()
  File "/Users/gparvin/ACM/src/secure-engineering-automation/assessment/2.2sprint5/KubiScan/engine/utils.py", line 140, in get_risky_roles
    return get_risky_role_by_kind('Role')
  File "/Users/gparvin/ACM/src/secure-engineering-automation/assessment/2.2sprint5/KubiScan/engine/utils.py", line 126, in get_risky_role_by_kind
    risky_roles = find_risky_roles(all_roles.items, kind)
  File "/Users/gparvin/ACM/src/secure-engineering-automation/assessment/2.2sprint5/KubiScan/engine/utils.py", line 105, in find_risky_roles
    is_risky, priority = is_risky_role(role)
  File "/Users/gparvin/ACM/src/secure-engineering-automation/assessment/2.2sprint5/KubiScan/engine/utils.py", line 94, in is_risky_role
    if are_rules_contain_other_rules(role.metadata.name, role.rules, risky_role.rules):
  File "/Users/gparvin/ACM/src/secure-engineering-automation/assessment/2.2sprint5/KubiScan/engine/utils.py", line 81, in are_rules_contain_other_rules
    for source_rule in source_rules:
TypeError: 'NoneType' object is not iterable
```

The command being run was: `python3 ./KubiScan/KubiScan.py -rr`
I have not done much extra testing on OpenShift to determine if there are other similar scenarios where an error like this occurs.

### What ticket does this PR close?
I have not opened a separate issue for this PR.  Let me know if you want one for tracking.

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
