### PR TITLE
Resolve errors encountered running kubiscan in openshift and from a container image

### DIFF
--- a/KubiScan.py
+++ b/KubiScan.py
@@ -346,7 +346,7 @@ def parse_pod_spec(pod_spec, container):
             if key == 'host_pid' or key == 'host_ipc' or key == 'host_network':
                 spec += '{0}: {1}\n'.format(key, dict[key])
 
-            if key == 'volumes':
+            if key == 'volumes' and container.volume_mounts is not None:
                 for volume_obj in dict[key]:
                     if 'host_path' in volume_obj:
                         if volume_obj['host_path']:

--- a/api/api_client.py
+++ b/api/api_client.py
@@ -3,6 +3,8 @@ from shutil import copyfile
 import os
 from tempfile import mkstemp
 from shutil import move
+from kubernetes.client.configuration import Configuration
+from kubernetes.client.api_client import ApiClient
 
 # TODO: Should be removed after the bug will be solved:
 # https://github.com/kubernetes-client/python/issues/577
@@ -55,7 +57,13 @@ def api_init(host=None, token_filename=None, cert_filename=None, context=None):
             cert_filename = os.path.abspath(cert_filename)
         BearerTokenLoader(host=host, token_filename=token_filename, cert_filename=cert_filename).load_and_set()
 
+        CoreV1Api = client.CoreV1Api()
+        RbacAuthorizationV1Api = client.RbacAuthorizationV1Api()
+        api_temp = ApiClientTemp()
+
     else:
+        configuration = Configuration()
+        api_client = ApiClient()
         if running_in_docker_container():
             # TODO: Consider using config.load_incluster_config() from container created by Kubernetes. Required service account with privileged permissions.
             # Must have mounted volume
@@ -65,13 +73,14 @@ def api_init(host=None, token_filename=None, cert_filename=None, context=None):
                 copyfile(container_volume_prefix + os.path.expandvars('$CONF_PATH'), kube_config_bak_path)
                 replace(kube_config_bak_path, ': /', ': /tmp/')
 
-            config.load_kube_config(kube_config_bak_path, context=context)
+            config.load_kube_config(kube_config_bak_path, context=context, client_configuration=configuration)
         else:
-            config.load_kube_config(context=context)
+            config.load_kube_config(context=context, client_configuration=configuration)
 
-    CoreV1Api = client.CoreV1Api()
-    RbacAuthorizationV1Api = client.RbacAuthorizationV1Api()
-    api_temp = ApiClientTemp()
+        api_client = ApiClient(configuration=configuration)
+        CoreV1Api = client.CoreV1Api(api_client=api_client)
+        RbacAuthorizationV1Api = client.RbacAuthorizationV1Api(api_client=api_client)
+        api_temp = ApiClientTemp(configuration=configuration)
 
 class BearerTokenLoader(object):
     def __init__(self, host, token_filename, cert_filename=None):

--- a/engine/utils.py
+++ b/engine/utils.py
@@ -78,12 +78,13 @@ def are_rules_contain_other_rules(source_role_name, source_rules, target_rules):
     is_contains = False
     matched_rules = 0
     for target_rule in target_rules:
-        for source_rule in source_rules:
-            if is_rule_contains_risky_rule(source_role_name, source_rule, target_rule):
-                matched_rules += 1
-                if matched_rules == len(target_rules):
-                    is_contains = True
-                    return is_contains
+        if source_rules is not None:
+            for source_rule in source_rules:
+                if is_rule_contains_risky_rule(source_role_name, source_rule, target_rule):
+                    matched_rules += 1
+                    if matched_rules == len(target_rules):
+                        is_contains = True
+                        return is_contains
 
     return is_contains
 


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made? This resolves exceptions that happen when running kubiscan on an OpenShift cluster.
- _How should the reviewer approach this PR, especially if manual tests are required? I'd like to run the test automation but I don't see instructions.  I've manually tested many commands and this PR contains the fixes I needed to get it to work.  I'm not clear on how my changes to the api client may limit other test scenarios.  I can try testing against other k8s cluster types if necessary.
- _Are there relevant screenshots you can add to the PR description?  See info below for some errors I was encountering.

Stack trace for exception running on OpenShift:
```
Traceback (most recent call last):
  File "./KubiScan/KubiScan.py", line 635, in <module>
    main()
  File "./KubiScan/KubiScan.py", line 554, in main
    print_risky_roles(show_rules=args.rules, days=args.less_than, priority=args.priority)
  File "./KubiScan/KubiScan.py", line 52, in print_risky_roles
    risky_roles = engine.utils.get_risky_roles()
  File "/Users/gparvin/ACM/src/secure-engineering-automation/assessment/2.2sprint5/KubiScan/engine/utils.py", line 140, in get_risky_roles
    return get_risky_role_by_kind('Role')
  File "/Users/gparvin/ACM/src/secure-engineering-automation/assessment/2.2sprint5/KubiScan/engine/utils.py", line 126, in get_risky_role_by_kind
    risky_roles = find_risky_roles(all_roles.items, kind)
  File "/Users/gparvin/ACM/src/secure-engineering-automation/assessment/2.2sprint5/KubiScan/engine/utils.py", line 105, in find_risky_roles
    is_risky, priority = is_risky_role(role)
  File "/Users/gparvin/ACM/src/secure-engineering-automation/assessment/2.2sprint5/KubiScan/engine/utils.py", line 94, in is_risky_role
    if are_rules_contain_other_rules(role.metadata.name, role.rules, risky_role.rules):
  File "/Users/gparvin/ACM/src/secure-engineering-automation/assessment/2.2sprint5/KubiScan/engine/utils.py", line 81, in are_rules_contain_other_rules
    for source_rule in source_rules:
TypeError: 'NoneType' object is not iterable
```

Stack trace from running in a container:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/urllib3/connection.py", line 170, in _new_conn
    (self._dns_host, self.port), self.timeout, **extra_kw
  File "/usr/local/lib/python3.6/site-packages/urllib3/util/connection.py", line 96, in create_connection
    raise err
  File "/usr/local/lib/python3.6/site-packages/urllib3/util/connection.py", line 86, in create_connection
    sock.connect(sa)
ConnectionRefusedError: [Errno 111] Connection refused

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py", line 706, in urlopen
    chunked=chunked,
  File "/usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py", line 394, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/usr/local/lib/python3.6/site-packages/urllib3/connection.py", line 234, in request
    super(HTTPConnection, self).request(method, url, body=body, headers=headers)
  File "/usr/lib64/python3.6/http/client.py", line 1254, in request
# BUILD
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/lib64/python3.6/http/client.py", line 1300, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/usr/lib64/python3.6/http/client.py", line 1249, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/usr/lib64/python3.6/http/client.py", line 1036, in _send_output
    self.send(msg)
  File "/usr/lib64/python3.6/http/client.py", line 974, in send
    self.connect()
  File "/usr/local/lib/python3.6/site-packages/urllib3/connection.py", line 200, in connect
    conn = self._new_conn()
  File "/usr/local/lib/python3.6/site-packages/urllib3/connection.py", line 182, in _new_conn
    self, "Failed to establish a new connection: %s" % e
urllib3.exceptions.NewConnectionError: <urllib3.connection.HTTPConnection object at 0x7f6058bfb7b8>: Failed to establish a new connection: [Errno 111] Connection refused

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/KubiScan/KubiScan.py", line 635, in <module>
    main()
  File "/KubiScan/KubiScan.py", line 556, in main
    print_risky_clusterroles(show_rules=args.rules, days=args.less_than, priority=args.priority)
  File "/KubiScan/KubiScan.py", line 60, in print_risky_clusterroles
    risky_clusterroles = engine.utils.get_risky_clusterroles()
  File "/KubiScan/engine/utils.py", line 144, in get_risky_clusterroles
    return get_risky_role_by_kind('ClusterRole')
  File "/KubiScan/engine/utils.py", line 124, in get_risky_role_by_kind
    all_roles = get_roles_by_kind(kind)
  File "/KubiScan/engine/utils.py", line 118, in get_roles_by_kind
    all_roles = api_client.api_temp.list_cluster_role()
  File "/KubiScan/api/api_client_temp.py", line 667, in list_cluster_role
    _request_timeout=None)
  File "/KubiScan/api/api_client_temp.py", line 155, in __call_api
    _request_timeout=_request_timeout)
  File "/KubiScan/api/api_client_temp.py", line 344, in request
    headers=headers)
  File "/usr/local/lib/python3.6/site-packages/kubernetes/client/rest.py", line 243, in GET
    query_params=query_params)
  File "/usr/local/lib/python3.6/site-packages/kubernetes/client/rest.py", line 216, in request
    headers=headers)
  File "/usr/local/lib/python3.6/site-packages/urllib3/request.py", line 75, in request
    method, url, fields=fields, headers=headers, **urlopen_kw
  File "/usr/local/lib/python3.6/site-packages/urllib3/request.py", line 96, in request_encode_url
    return self.urlopen(method, url, **extra_kw)
  File "/usr/local/lib/python3.6/site-packages/urllib3/poolmanager.py", line 375, in urlopen
    response = conn.urlopen(method, u.request_uri, **kw)
  File "/usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py", line 796, in urlopen
    **response_kw
  File "/usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py", line 796, in urlopen
    **response_kw
  File "/usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py", line 796, in urlopen
    **response_kw
  File "/usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py", line 756, in urlopen
    method, url, error=e, _pool=self, _stacktrace=sys.exc_info()[2]
  File "/usr/local/lib/python3.6/site-packages/urllib3/util/retry.py", line 573, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPConnectionPool(host='localhost', port=80): Max retries exceeded with url: /apis/rbac.authorization.k8s.io/v1/clusterroles (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f6058bfb7b8>: Failed to establish a new connection: [Errno 111] Connection refused',))
```

### What ticket does this PR close?
I did not open a ticket.

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests 

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
