### PR TITLE
Fixed bug with missing configuration object when using token

### DIFF
--- a/api/api_client.py
+++ b/api/api_client.py
@@ -55,11 +55,11 @@ def api_init(kube_config_file=None, host=None, token_filename=None, cert_filenam
         token_filename = os.path.abspath(token_filename)
         if cert_filename:
             cert_filename = os.path.abspath(cert_filename)
-        BearerTokenLoader(host=host, token_filename=token_filename, cert_filename=cert_filename).load_and_set()
+        configuration = BearerTokenLoader(host=host, token_filename=token_filename, cert_filename=cert_filename).load_and_set()
 
         CoreV1Api = client.CoreV1Api()
         RbacAuthorizationV1Api = client.RbacAuthorizationV1Api()
-        api_temp = ApiClientTemp()
+        api_temp = ApiClientTemp(configuration=configuration)
 
     elif kube_config_file:
         config.load_kube_config(os.path.abspath(kube_config_file))
@@ -102,7 +102,9 @@ class BearerTokenLoader(object):
 
     def load_and_set(self):
         self._load_config()
-        self._set_config()
+        configuration = self._set_config()
+        return configuration
+
 
     def _load_config(self):
         self._host = "https://" + self._host
@@ -133,3 +135,4 @@ class BearerTokenLoader(object):
         configuration.verify_ssl = self._verify_ssl
         configuration.api_key['authorization'] = "bearer " + self.token
         client.Configuration.set_default(configuration)
+        return configuration


### PR DESCRIPTION
### Desired Outcome

When calling KubiScan like that:
```
kubiscan -ho 192.168.58.2:8443 -t /home/natan/token -rs
```

Receiving multiple errors such as:
```
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='192.168.58.2', port=8443): Max retries exceeded with url: /apis/rbac.authorization.k8s.io/v1/roles (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f9f8c7826b0>: Failed to establish a new connection: [Errno 113] No route to host'))
```

### Implemented Changes

The problem was that the `Configuration`  object was with default fields although it was initialized in the `BearerTokenLoader(..).load_and_set()` function.  
We fixed it by returning the configuration to `ApiClientTemp()`.



#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update


#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR


