### PR TITLE
Explicitly install pip3 for alpine based image

### DIFF
--- a/DockerHubDockerfileAlpine
+++ b/DockerHubDockerfileAlpine
@@ -1,5 +1,5 @@
 FROM alpine:latest
-RUN apk update && apk upgrade && apk add bash && apk add python3 && pip3 install requests && pip3 install PTable
+RUN apk update && apk upgrade && apk add bash && apk add python3 && apk add cmd:pip3 && pip3 install requests && pip3 install PTable
 RUN apk add git && git clone --recursive https://github.com/kubernetes-client/python.git && cd python/ && python3 setup.py install 
 RUN echo "alias kubiscan='python3 /KubiScan/KubiScan.py'" > /root/.bash_aliases && echo "alias kubiscan='python3 /KubiScan/KubiScan.py'" > /root/.bashrc
 RUN . /root/.bash_aliases

--- a/DockerfileAlpine
+++ b/DockerfileAlpine
@@ -1,5 +1,5 @@
 FROM alpine:latest
-RUN apk update && apk upgrade && apk add bash && apk add python3 && pip3 install requests && pip3 install PTable
+RUN apk update && apk upgrade && apk add bash && apk add python3 && apk add cmd:pip3 && pip3 install requests && pip3 install PTable
 RUN apk add git && git clone --recursive https://github.com/kubernetes-client/python.git && cd python/ && python3 setup.py install 
 RUN echo "alias kubiscan='python3 /KubiScan/KubiScan.py'" > /root/.bash_aliases && echo "alias kubiscan='python3 /KubiScan/KubiScan.py'" > /root/.bashrc
 RUN . /root/.bash_aliases


### PR DESCRIPTION
### Desired Outcome
Alpine docker build should complete successfully after this PR is merged.

Current error: `pip3: not found`
```
 > [2/6] RUN apk update && apk upgrade && apk add bash && apk add python3 && pip3 install requests && pip3 install PTable:
#5 1.599 (2/10) Installing expat (2.4.8-r0)
#5 1.623 (3/10) Installing libffi (3.4.2-r1)
#5 1.635 (4/10) Installing gdbm (1.23-r0)
#5 1.647 (5/10) Installing xz-libs (5.2.5-r1)
#5 1.663 (6/10) Installing libgcc (11.2.1_git20220219-r2)
#5 1.676 (7/10) Installing libstdc++ (11.2.1_git20220219-r2)
#5 1.711 (8/10) Installing mpdecimal (2.5.1-r1)
#5 1.726 (9/10) Installing sqlite-libs (3.38.5-r0)
#5 1.749 (10/10) Installing python3 (3.10.5-r0)
pip3: not found
------
./DockerfileAlpine:2
--------------------
   1 |     FROM alpine:latest
   2 | >>> RUN apk update && apk upgrade && apk add bash && apk add python3 && pip3 install requests && pip3 install PTable
   3 |     RUN apk add git && git clone --recursive https://github.com/kubernetes-client/python.git && cd python/ && python3 setup.py install 
   4 |     RUN echo "alias kubiscan='python3 /KubiScan/KubiScan.py'" > /root/.bash_aliases && echo "alias kubiscan='python3 /KubiScan/KubiScan.py'" > /root/.bashrc
--------------------
ERROR: failed to solve: process "/bin/sh -c apk update && apk upgrade && apk add bash && apk add python3 && pip3 install requests && pip3 install PTable" did not complete successfully: exit code: 127
```

### Implemented Changes
Added `apk add cmd:pip3` in order to install `pip3`

### Connected Issue/Story
Resolves https://github.com/alpinelinux/docker-alpine/issues/91

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
