### PR TITLE
Add GitHub Actions to build and publish images

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,34 @@
+name: Master
+
+on:
+  push:
+    branches: master
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to ghcr.io
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          file: ./Dockerfile
+          push: true
+          tags: ghcr.io/cyberark/kubiscan:latest
+          platforms: linux/amd64
+      - name: Build and push (Alpine)
+        uses: docker/build-push-action@v2
+        with:
+          file: ./DockerfileAlpine
+          push: true
+          tags: ghcr.io/cyberark/kubiscan:alpine
+          platforms: linux/amd64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: Publish (Release)
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to ghcr.io
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          file: ./Dockerfile
+          push: true
+          tags: ghcr.io/cyberark/kubiscan:${{ github.event.release.tag_name }}
+          platforms: linux/amd64
+      - name: Build and push (Alpine)
+        uses: docker/build-push-action@v2
+        with:
+          file: ./DockerfileAlpine
+          push: true
+          tags: ghcr.io/cyberark/kubiscan:${{ github.event.release.tag_name }}-alpine
+          platforms: linux/amd64


### PR DESCRIPTION
### Desired Outcome
Images are build and released using GitHub Actions and ghcr.io automatically for each release and commit. The latest image is over 4 years old.

### Implemented Changes
Add GitHub Actions to build and release images.

### Connected Issue/Story

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
