### PR TITLE
Fix iteration for rolebindings without subjects

### DIFF
--- a/engine/utils.py
+++ b/engine/utils.py
@@ -218,7 +218,7 @@ def get_all_risky_subjects():
     all_risky_rolebindings = get_all_risky_rolebinding()
     passed_users = {}
     for risky_rolebinding in all_risky_rolebindings:
-        for user in risky_rolebinding.subjects:
+        for user in risky_rolebinding.subjects or []:
             # Removing duplicated users
             if ''.join((user.kind, user.name, str(user.namespace))) not in passed_users:
                 passed_users[''.join((user.kind, user.name, str(user.namespace)))] = True
@@ -371,7 +371,7 @@ def get_rolebindings_and_clusterrolebindings_associated_to_subject(subject_name,
     associated_rolebindings = []
 
     for rolebinding in rolebindings_all_namespaces.items:
-        for subject in rolebinding.subjects:
+        for subject in rolebinding.subjects or []:
             if subject.name.lower() == subject_name.lower() and subject.kind.lower() == kind.lower():
                 if kind == SERVICEACCOUNT_KIND:
                     if subject.namespace.lower() == namespace.lower():
@@ -381,7 +381,7 @@ def get_rolebindings_and_clusterrolebindings_associated_to_subject(subject_name,
 
     associated_clusterrolebindings = []
     for clusterrolebinding in cluster_rolebindings:
-        for subject in clusterrolebinding.subjects:
+        for subject in clusterrolebinding.subjects or []:
             if subject.name == subject_name.lower() and subject.kind.lower() == kind.lower():
                 if kind == SERVICEACCOUNT_KIND:
                     if subject.namespace.lower() == namespace.lower():
@@ -475,10 +475,12 @@ def get_subjects_by_kind(kind):
     rolebindings = api_client.RbacAuthorizationV1Api.list_role_binding_for_all_namespaces()
     clusterrolebindings = api_client.api_temp.list_cluster_role_binding()
     for rolebinding in rolebindings.items:
-        subjects_found += search_subject_in_subjects_by_kind(rolebinding.subjects, kind)
+        if rolebinding.subjects is not None:
+            subjects_found += search_subject_in_subjects_by_kind(rolebinding.subjects, kind)
 
     for clusterrolebinding in clusterrolebindings:
-        subjects_found += search_subject_in_subjects_by_kind(clusterrolebinding.subjects, kind)
+        if clusterrolebinding.subjects is not None:
+            subjects_found += search_subject_in_subjects_by_kind(clusterrolebinding.subjects, kind)
 
     return remove_duplicated_subjects(subjects_found)
 


### PR DESCRIPTION
### Desired Outcome
In OpenShift, there are RoleBindings without subjects, which leads to problems: 
```
Traceback (most recent call last):
  File "/KubiScan/KubiScan.py", line 639, in <module>
    main()
  File "/KubiScan/KubiScan.py", line 574, in main
    print_all(days=args.less_than, priority=args.priority, read_token_from_container=args.deep)
  File "/KubiScan/KubiScan.py", line 140, in print_all
rint_all_risky_subjects(priority=priority)
  File "/KubiScan/KubiScan.py", line 126, in print_all_risky_subjects
    subjects = engine.utils.get_all_risky_subjects()
  File "/KubiScan/engine/utils.py", line 221, in get_all_risky_subjects
    for user in risky_rolebinding.subjects:
TypeError: 'NoneType' object is not iterable
command terminated with exit code 1
```

### Implemented Changes
Add checks for subjects in RoleBindings not equals `None` in order to prevet `TypeError: 'NoneType' object is not iterable`. I saw that you added the "ApiClientTemp" for the rules in Roles, but I don't think it's worth cop/pasting more external code, so I decided to just add checks.

### Connected Issue/Story
Similar to https://github.com/cyberark/KubiScan/issues/1
Related to https://github.com/kubernetes-client/python/issues/577, https://github.com/kubernetes-client/gen/issues/52

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
