### PR TITLE
Fixing the path to '/opt/kubiscan/config_bak' like in the Dockerfile

### DIFF
--- a/api/api_client.py
+++ b/api/api_client.py
@@ -77,7 +77,7 @@ def api_init(kube_config_file=None, host=None, token_filename=None, cert_filenam
             # TODO: Consider using config.load_incluster_config() from container created by Kubernetes. Required service account with privileged permissions.
             # Must have mounted volume
             container_volume_prefix = os.getenv('KUBISCAN_VOLUME_PATH', '/tmp')
-            kube_config_bak_path = os.getenv('KUBISCAN_CONFIG_BACKUP_PATH', '/opt/KubiScan/config_bak')
+            kube_config_bak_path = os.getenv('KUBISCAN_CONFIG_BACKUP_PATH', '/opt/kubiscan/config_bak')
             if not os.path.isfile(kube_config_bak_path):
                 copyfile(container_volume_prefix + os.path.expandvars('$CONF_PATH'), kube_config_bak_path)
                 replace(kube_config_bak_path, ': /', f': {container_volume_prefix}/')


### PR DESCRIPTION
### Desired Outcome

Fix the path so it will work in a container
### Implemented Changes

Fixing the path to '/opt/kubiscan/config_bak' like in the Dockerfile

- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

### Definition of Done

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
