### PR TITLE
Printing error message when no kind was entered to '-aars' flag

### DIFF
--- a/KubiScan.py
+++ b/KubiScan.py
@@ -645,6 +645,8 @@ Requirements:
                     print('For ServiceAccount kind specify namespace (-ns, --namespace)')
             else:
                 print_rules_associated_to_subject(args.associated_any_roles_subject, args.kind)
+        else:
+            print("Please specify kind (-k, --kind).")
     elif args.dump_tokens:
         if args.name:
             if args.namespace:


### PR DESCRIPTION
### Desired Outcome

Printing error message when no kind was entered to '-aars' flag

### Implemented Changes

Printing error message when no kind was entered to '-aars' flag

### Connected Issue/Story


CyberArk internal issue link: [insert issue ID]()

### Definition of Done


#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
