### PR TITLE
Fix error when a secret with name 'token' is not a jwt.

### DIFF
--- a/engine/utils.py
+++ b/engine/utils.py
@@ -415,7 +415,11 @@ def get_jwt_and_decode(pod, risky_users, volume):
         secret = None
     if secret is not None and secret.data is not None:
         if 'token' in secret.data:
-            decoded_data = decode_base64_jwt_token(secret.data['token'])
+            try:
+                decoded_data = decode_base64_jwt_token(secret.data['token'])
+            except:
+                print(f'[!] Can\'t decode token in secret {secret.metadata.name} in {secret.metadata.namespace if hasattr(secret.metadata, "namespace") else "at cluster scope"} (may be its not a jwt token)')
+                return None
             token_body = json.loads(decoded_data)
             if token_body:
                 risky_user = get_risky_user_from_container(token_body, risky_users)


### PR DESCRIPTION
When a secret has a data with the name 'token' that is not a jwt token, this will raise an exception and end the script (even if scan is not finished).

### Desired Outcome

When a secret has a key named 'token', sometimes its not a real jwt token.

For example, this is the case on openshift with the secret 'telemeter-client' in namespace 'openshift-monitoring'.

This PR print a warning to give the user a chance to investigate the issue.

This solution has disadvantages :
- This break the display
- This can be a warning event if the problem is not an issue

I don't know if its better to silently ignore the error or to display a warning

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

(see engine.utils.get_jwt_and_decode)

When a secret is discovered, we check the name and if its 'token', we try to decode the jwt and return the user.

With this commit, and error on decode the jwt will just print a warning and return None, just like a secret without the token key.

There is other ways to manage the issue whitout a try/except :

- check if the jwt is a token before decode it, but we will decode 2 times the token
- check if the jwt is a token when decode it but this will force the function engine.jwt_token.decode_base64_jwt_token to return None without give the user why this value is return.

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [insert issue ID]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests


#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [X] There are no security aspects to these changes
