### PR TITLE
closes #66

### DIFF
--- a/docker_run.sh
+++ b/docker_run.sh
@@ -106,6 +106,6 @@ then
   docker cp "$certificate_auth" "$kubiscan_container_id":/tmp/"$certificate_auth"
 fi
 # Giving permissions to /tmp and opt/KubiScan
-docker exec -it "$kubiscan_container_id" bash -c "chmod -R 777 /tmp /opt/kubiscan /home/kubiscan"
+docker exec -it "$kubiscan_container_id" bash -c "chmod -fR 777 /tmp /opt/kubiscan /home/kubiscan"
 docker exec -it --user kubiscan "$kubiscan_container_id" bash
 


### PR DESCRIPTION
### Desired Outcome

Not presenting the error message from `chmod` error (#66).

### Implemented Changes

the `-f` flag silently ignores this error, alternatively the [`mkdir` command](https://github.com/cyberark/KubiScan/blob/cd670a671454c99487327942332fa5a6697037f3/docker_run.sh#L28) could be moved outside of the `if` statement.

- _What's changed? Why were these changes made?_
  - This is just having it silently ignore the directory doesn't exist.
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

Resolves #66 

CyberArk internal issue ID: N/a

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [X] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [X] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [X] There are no security aspects to these changes
